### PR TITLE
Fix typo in tutorial

### DIFF
--- a/htdocs/tutorial/tutorial.html
+++ b/htdocs/tutorial/tutorial.html
@@ -202,7 +202,7 @@ volvox database directory.  On Unix systems:
 <blockquote class="example">
 <pre>
 % <b>cd /var/www/gbrowse2</b>
-% <b>cp tutorial/data_files/volvox_remarks.gff3 databases/volvox</b>
+% <b>cp tutorial/data_files/volvox_remarks.gff3 /var/lib/gbrowse2/databases/volvox</b>
 </pre>
 </blockquote>
 


### PR DESCRIPTION
The tutorial suggests that the new user copy the volvox gff file into /var/www/gbrowse2/databases/volvox, which of course doesn't exist.
This commit suggests to the user that they copy the gff into the directory they just created at /var/lib/gbrowse2/databases/volvox.
