### PR TITLE
Increase FcgidMaxRequestLen to 128MB to allow larger file uploads under

### DIFF
--- a/install_util/GBrowseInstall.pm
+++ b/install_util/GBrowseInstall.pm
@@ -396,6 +396,8 @@ ScriptAlias  "/gb2"      "$cgibin"
   FcgidMinProcessesPerClass 6
   FcgidIOTimeout   600
   FcgidBusyTimeout 600
+  # allow larger file uploads up to 128M under FastCGI (default is 128K)
+  FcgidMaxRequestLen 134217728
   $fcgid_inc
 </IfModule>
 


### PR DESCRIPTION
Here's a patch for the bug described at the SourceForge bug tracker, where large file uploads fail when mod_fcgid is used due to the small default limit (128K) of FcgidMaxRequestLen:

http://sourceforge.net/tracker/?func=detail&aid=3313202&group_id=27707&atid=391291
