### PR TITLE
Trim leading & trailing spaces from the search term

### DIFF
--- a/lib/Bio/Graphics/Browser2/Region.pm
+++ b/lib/Bio/Graphics/Browser2/Region.pm
@@ -201,6 +201,7 @@ sub search_db {
   my ($features);
   if (my $name = $args->{-search_term}) {
       $name =~ tr/a-zA-Z0-9|.'"_*?: ;+-\/\#\[\]//cd;  # remove rude/naughty characters
+      $name =~ s/^\s+|\s+$//g; # trim leading & trailing whitespace
       my ($ref,$start,$stop,$class,$id) = $self->parse_feature_name($name);
       $features =  $self->lookup_features($ref,$start,$stop,$class,$name,$id);
   }


### PR DESCRIPTION
We encountered an issue where having one or more leading spaces in a search term caused the search to return many spurious results, while trailing spaces at the end of a search term caused the search to fail. Trimming leading/trailing whitespace resolved the issue.

I'm not sure if this is the best location for this code, but it works for search terms entered in the "Landmark or Region" box.
