### PR TITLE
Quell intermittent PrimerDesigner errors when run under mod_fcgid instead of mod_perl

### DIFF
--- a/conf/plugins/PrimerDesigner.pm
+++ b/conf/plugins/PrimerDesigner.pm
@@ -102,8 +102,9 @@ use vars qw/@ISA $PNG $CALL/;
 
 # Arg, modperl
 END {
-	
-  CGI::Delete_all();
+  if ($ENV{'MOD_PERL'}) {
+    CGI::Delete_all();
+  }
 }
 
 


### PR DESCRIPTION
The following intermittent errors were observed running GBrowse on Apache 2.2.26, mod_fcgid 2.3.9, Perl 5.16.3, and CGI.pm 3.63:

<h1>Software error:</h1>

<pre>Undefined subroutine CGI::Pretty::delete_all
 at /opt/gbrowse/conf/plugins/PrimerDesigner.pm line 106.
END failed--call queue aborted at /opt/gbrowse/cgi-bin/gbrowse line 55.
</pre>

<p>
For help, please send mail to the webmaster (<a href="mailto:you@example.com">you@example.com</a>), giving this error message
and the time and date of the error.
</p>


From the comment above the END code block, it appears that the call to CGI::Delete_all() is there for mod_perl. We have not observed the errors since wrapping the call in an <b>if</b> statement to conditionally execute it only if the MOD_PERL environment variable is set.
