### PR TITLE
BLAT plugin fixes

### DIFF
--- a/conf/plugins/Blat.pm
+++ b/conf/plugins/Blat.pm
@@ -121,35 +121,69 @@ sub find {
 
   open (IN, "$out_file") || die "couldn't open $out_file $!\n";
   my $hit_count = 0;
+  my @blat_hits;
+  # indexes each blat hit array of @blat_hits
+  use constant {
+    MATCHES       => 0,
+    MISMATCHES    => 1,
+    REP_MATCHES   => 2,
+    N_COUNT       => 3,
+    Q_NUM_INSERT  => 4,
+    Q_BASE_INSERT => 5,
+    T_NUM_INSERT  => 6,
+    T_BASE_INSERT => 7,
+    STRAND        => 8,
+    Q_NAME        => 9,
+    Q_LENGTH      => 10,
+    Q_START       => 11,
+    Q_END         => 12,
+    T_NAME        => 13,
+    T_LENGTH      => 14,
+    T_START       => 15,
+    T_END         => 16,
+    BLOCK_COUNT   => 17,
+    BLOCK_SIZES   => 18,
+    Q_STARTS      => 19,
+    T_STARTS      => 20,
+  };
+
   while(<IN>) {
+    push (@blat_hits, [ split ]);
+  }
+
+  for my $hit (
+    # sort hits in descending order by calculated score
+    sort {
+      ($b->[MATCHES]+$b->[MISMATCHES]+$b->[REP_MATCHES])/$b->[Q_LENGTH]
+      <=>
+      ($a->[MATCHES]+$a->[MISMATCHES]+$a->[REP_MATCHES])/$a->[Q_LENGTH]
+    } @blat_hits
+  ) {
     last if ++$hit_count > $hits;
-    # this could probably be done better but ...
-    my ( $matches,$mismatches,$rep_matches,$n_count,$q_num_insert,$q_base_insert,$t_num_insert, $t_base_insert,
-         $strand,$q_name,$q_length,$q_start,$q_end,$t_name,$t_length,$t_start,$t_end,$block_count,$block_sizes,
-         $q_starts,$t_starts) = split;
     
-    $block_sizes =~ s/\,$//;	      # remove trailing comma from block_sizes string     
-    $t_starts	 =~ s/\,$//;	      # .. and from t_starts string
-    my $score = sprintf "%.2f", ( 100 * ( $matches + $mismatches + $rep_matches ) / $q_length );
-    my $percent_id = sprintf "%.2f", ( 100 * ($matches + $rep_matches)/( $matches + $mismatches + $rep_matches ));
-    my $alignment = Bio::Graphics::Feature->new(-start=>$t_start,
-						-end  =>$t_end,
-						-ref => $t_name,
+    $hit->[BLOCK_SIZES] =~ s/\,$//;      # remove trailing comma from block_sizes string     
+    $hit->[T_STARTS]    =~ s/\,$//;      # .. and from t_starts string
+    my $score = sprintf "%.2f", ( 100 * ( $hit->[MATCHES] + $hit->[MISMATCHES] + $hit->[REP_MATCHES] ) / $hit->[Q_LENGTH] );
+    my $percent_id = sprintf "%.2f", ( 100 * ($hit->[MATCHES] + $hit->[REP_MATCHES]) /
+                                             ($hit->[MATCHES] + $hit->[MISMATCHES] + $hit->[REP_MATCHES]));
+    my $alignment = Bio::Graphics::Feature->new(-start=>$hit->[T_START]+1,
+						-end  =>$hit->[T_END],
+						-ref => $hit->[T_NAME],
 						-type=>'BLAT',
 						-name => "Alignment$hit_count",
-						-strand => $strand,
+						-strand => ($hit->[STRAND] eq '+') ? 1 : -1,
 						-score => $score
 					       );
     
-    @hit_starts = split(",", $t_starts);
-    @block_sizes = split(",", $block_sizes);
-    for($i=0;$i<$block_count;$i++){	# if multihit alignments (block_count > 1), aggregate.
+    @hit_starts = map { $_ + 1 } split(",", $hit->[T_STARTS]);
+    @block_sizes = split(",", $hit->[BLOCK_SIZES]);
+    for($i=0;$i<$hit->[BLOCK_COUNT];$i++){      # if multihit alignments (block_count > 1), aggregate.
       my $sub_alignment = Bio::Graphics::Feature->new(-start=>$hit_starts[$i],
         				      -end  =>($hit_starts[$i]+$block_sizes[$i]),
-        				      -ref => $t_name,
+        				      -ref => $hit->[T_NAME],
         				      -type=>'BLAT',
         				      -name => 'Alignment',
-        				      -strand => $strand,
+        				      -strand => ($hit->[STRAND] eq '+') ? 1 : -1,
         				      -score => $percent_id
         				     );
       $alignment->add_segment($sub_alignment);

--- a/lib/Bio/Graphics/Browser2/Render.pm
+++ b/lib/Bio/Graphics/Browser2/Render.pm
@@ -1674,7 +1674,7 @@ sub write_auto {
         my $position
             = $f->sub_SeqFeature
             ? join( ',',
-            map { $_->start . '..' . $_->end } $f->sub_SeqFeature )
+            map { $_->strand >= 0 ? $_->start . '..' . $_->end : $_->end . '..' . $_->start } $f->sub_SeqFeature )
             : $f->start . '..' . $f->end;
         $name .= "($seenit{$name})" if $seenit{$name}++;
         $feature_file .= "\nreference=$reference\n";


### PR DESCRIPTION
This proposed update to the BLAT plugin allows the user to specify a minimum percent identity---the default of 90 can be too stringent for cross-species alignment---and allows the user to select whether the query is dna or rna (previously, the query type was hard-coded to dna, and we tend to use the BLAT plugin to align transcripts).

![q_minidentity](https://cloud.githubusercontent.com/assets/1800812/3690410/88cd7df4-1348-11e4-9186-521e41eff289.png)

In addition, the proposed update fixes several issues:
- BLAT hits are not necessarily reported in best-to-worst order.

The BLAT plugin currently keeps the first "Number of Hits to Return" hits in the PSL output (default 5). BLAT doesn't necessarily report hits in best-to-worst order, however. Compare the results from "Number of Hits to Return: 5":

![orig-keep5](https://cloud.githubusercontent.com/assets/1800812/3000062/e905c934-dd1e-11e3-8985-6cfb19ecd471.png)

with "Number of Hits to Return: 10":

![orig-keep10](https://cloud.githubusercontent.com/assets/1800812/3000069/f6d3e3a2-dd1e-11e3-98c3-fbcc614fce43.png)

The best hit was only reported in the second set, as it did not appear in the first 5 reported hits in the BLAT PSL file. The erroneous start coordinate of the best hit, which starts at the beginning of the sequence, is a side effect of issue #2:
- Start coordinates in PSL output are 0-based, not 1-based.

The proposed patch reads all BLAT hits and sorts them by the calculated score (which appears to be percent query coverage---a separate issue is whether it would be better to exclude mismatches) and adds one to all start coordinates, resulting in the following results with "Number of Hits to Return: 5":

![fixed-keep5](https://cloud.githubusercontent.com/assets/1800812/3000137/eaa6d00c-dd1f-11e3-9d63-056d4944e685.png)

This patch also changes the strand argument to Bio::Graphics::Feature to 1 or -1 instead of the "+" or "-" that is read from the PSL file, as the base class Bio::SeqFeature::Lite doesn't correctly handle "+" or "-", resulting in a 0 (".") for the strand (though I submitted a pull request to fix this: https://github.com/bioperl/bioperl-live/pull/71)
- Bio::Graphics::Browser2::Render does not handle "-" strand features in FeatureFile output

Even with the strand update to Blat.pm, the strand information isn't propagated to the resulting custom track that is created from the BLAT alignments; e.g., the following transcript alignment is on the "+" strand, while the gene model it was generated from is on the "-" strand:

![orig](https://cloud.githubusercontent.com/assets/1800812/3000527/0c6fcaea-dd25-11e3-946f-8e6f55c9340a.png)

The $userdata_base/*/My_Track/SOURCES/My_Track FeatureFile that was created from the BLAT alignments contains the following for that alignment:

```
reference=Gm01
"BLAT"  "Alignment1"    27946273..27946807,27950756..27950884,27952415..27952503,27952612..27956334,27957232..27957520
```

The documentation for Bio::DB::SeqFeature::Store::FeatureFileLoader states:

```
  Column 3: The position of this feature in base pair
            coordinates... Minus-strand features are indicated by specifying a start > end.
```

The proposed mod to Bio::Graphics::Browser2::Render uses end..start instead of start..end if the feature's strand is "-". The resulting alignment is then rendered on the correct strand:
![fixed](https://cloud.githubusercontent.com/assets/1800812/3000596/c2f3e210-dd25-11e3-93e7-66f7febd9054.png)
