### PR TITLE
Search results return only one feature with the same type, start, and end

### DIFF
--- a/lib/Bio/Graphics/Browser2/RegionSearch.pm
+++ b/lib/Bio/Graphics/Browser2/RegionSearch.pm
@@ -315,6 +315,7 @@ sub search_features {
 		  lc $_->seq_id eq $state->{name}) # this hack gives special privileges to matches to seq_ids
 		 ? 'region' 
 		 : $_->primary_tag),
+		 $_->display_name,
 		 $_->seq_id,
 		 $_->start,
 		 $_->end,


### PR DESCRIPTION
A colleague and I noticed that a search returning multiple features would not display in the karyotype view more than one feature of a given type when the start & end coordinates were the same. A comment in Bio::Graphics::Browser2::RegionSearch::search_features states that the results should be uniqueified when the name & type are the same, rather than type and start/end locations. I've tried to fix the issue by adding display_name to the mix of uniqueifying criteria.

This issue was first noted here:
http://sourceforge.net/p/gmod/mailman/message/26588306/

In response to the concern Scott Cain raised in that thread, I don't _think_ I've broken gbrowse_details---upon cursory inspection, it still seems to function---though to be sure it would be preferable if eyeballs from someone familiar with this section of code looked at it.
