### PR TITLE
Improve feature visibility in karyotype display

### DIFF
--- a/htdocs/css/karyotype.css
+++ b/htdocs/css/karyotype.css
@@ -1,9 +1,9 @@
 div.hilite {
     position:     absolute;
-    background:   lightblue;
+    background:   blue;
     cursor:       pointer;
     filter:       alpha(opacity=50);
-    opacity:      0.5;
+    opacity:      0.7;
 }
 div.nohilite {
     position:   absolute;
@@ -11,9 +11,9 @@ div.nohilite {
 }
 span.hilite {
     position:     absolute;
-    background:   lightblue;
+    background:   blue;
     filter:       alpha(opacity=50);
-    opacity:      0.5;
+    opacity:      0.7;
 }
 span.nohilite {
     position:   absolute;

--- a/lib/Bio/Graphics/Karyotype.pm
+++ b/lib/Bio/Graphics/Karyotype.pm
@@ -307,7 +307,6 @@ sub generate_panels {
 			      ? 'generic'
 			      : 'diamond';
 		      },
-		      -glyph => 'generic',
 		      -maxdepth => 0,
 		      -height  => 6,
 		      -bgcolor => 'red',


### PR DESCRIPTION
Originally, the karyotype display used a diamond glyph, for small features, and the "generic" glyph for large features. The use of the diamond glyph greatly improved visibility of these small features in the karyotype display, which otherwise would display as thin lines with the generic glyph. This functionality
appears to have been inadvertently disabled by commit 68e13af301d5fcd76e884ecafcc88c30270e6444, which sets the "glyph" argument to the Bio::Graphics::Panel::add_track method twice: the first calculates the glyph based on the feature length relative to the chromosome, while the second overrides the first, setting the glyph to "generic". This commit restores the original behavior.

In addition, when a user mouses over one of the features in the list produced below the karyotype display, the corresponding feature in the karyotype display is highlighted with a difficult-to-detect translucent pale blue. This commit also modifies the karyotype.css to change the highlighting to a darker blue to increase the contrast.

Example: in the original code, it is difficult to detect that the feature on the chromosome to the far left (Gm02) is highlighted:
![before](https://cloud.githubusercontent.com/assets/1800812/4476059/732bfba0-4972-11e4-8c57-26e8ab0775c5.png)

After this patch, it is much more obvious:
![after](https://cloud.githubusercontent.com/assets/1800812/4476082/a79e7430-4972-11e4-8271-ca818a7cf3ff.png)
