### PR TITLE
Left-align citation text in "?" menu.

### DIFF
--- a/lib/Bio/Graphics/Browser2/Render/HTML.pm
+++ b/lib/Bio/Graphics/Browser2/Render/HTML.pm
@@ -2227,7 +2227,7 @@ sub track_citation {
     my $id       = $self->tr('TRACK_ID',$label);
     my $download = a({-href=>"?l=$label;f=save+datafile"},$self->tr('DOWNLOAD_TRACK_DATA_ALL'));
     my $title    = div({-style => 'background:gainsboro;padding:5px;font-weight:bold'},$key,br(),$id,br(),$download);
-    return  join '',div({-style=>'text-align:center;font-size:small'},$title,$cit_html);
+    return  join '',div({-style=>'text-align:left;font-size:small'},$title,$cit_html);
 }
 
 sub download_track_menu {


### PR DESCRIPTION
In the "Browser" tab, when one clicks on the "?" above a track in the Details window, a popup containing the citation text appears. The text in this window is centered, unlike the text that appears in a new window when one click on the corresponding track name in the "Select Tracks" tab, which is left-aligned.

For consistency, I suggest also left-aligning the text in the popup. Left-aligning can also enhance readability when there is a lot of text; e.g. (before this patch):
![center](https://cloud.githubusercontent.com/assets/1800812/6485103/d39c28b4-c246-11e4-9609-17d67ee13fd9.png)

After this patch:
![left](https://cloud.githubusercontent.com/assets/1800812/6485117/e328128e-c246-11e4-96ab-a0763ef961c9.png)
