### PR TITLE
Avoid accumulating many .inverted files in the bio_graphics_ff_UID

### DIFF
--- a/lib/Bio/Graphics/Browser2/DataSource.pm
+++ b/lib/Bio/Graphics/Browser2/DataSource.pm
@@ -753,7 +753,7 @@ sub invert_types {
     my $config = shift;
     return unless $config;
 
-    my $keys         = md5_hex(keys %$config);
+    my $keys         = md5_hex(sort keys %$config);
 
     # check in-memory cache
     if (exists $self->{_inverted}{$keys}) {


### PR DESCRIPTION
While troubleshooting the cause of an "Internal Server Error" message that one of the data sources in our GBrowse instance was suddenly experiencing, I noticed that the bio_graphics_ff_cache_UID directory had accumulated many (762) *.inverted files since the GBrowse instance was put into production a few days ago. It seemed that one .inverted file was created for each new user/session (e.g., I could force the creation of a new .inverted file by using an "incognito" tab in Chrome).

I traced the cause of this to the code in
Bio::Graphics::Browser2::DataSource::invert_types that generates the file
name:

```
my $keys         = md5_hex(keys %$config);
...
my $inv_path     = $master_cache . ".${keys}.inverted";
```

Due to hash randomization introduced in Perl 5.18, "keys %$config" will differ between invocations:
http://perldoc.perl.org/perl5180delta.html#Hash-overhaul

The fix is to sort the keys before computing their md5:

```
my $keys         = md5_hex(sort keys %$config);
```

While I didn't identify the cause of the initial segfault, this fix should be sufficient to prevent its recurrence, as the symptom seemed to be the existence of the data-source-specific configuration "cache file" in the directory, which apparently under normal circumstances exists only briefly:

```
bio_graphics_ff_cache_80$ ls -lt
total 404
-rw-r--r--  1 www  www  20935 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf.87e6768252af88484bd145fe17ec6bf2.inverted
-rw-r--r--  1 www  www     24 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf.d41d8cd98f00b204e9800998ecf8427e.inverted
-rw-r--r--  1 www  www  20935 May 14 11:47 _opt_gbrowse_conf_gmax1.01.conf.2e50a0bde0f789e9cde3aed238d05ff3.inverted
...
bio_graphics_ff_cache_80$ ls -lt
total 540
-rw-r--r--  1 www  www  139264 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf
-rw-r--r--  1 www  www   20935 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf.87e6768252af88484bd145fe17ec6bf2.inverted
-rw-r--r--  1 www  www      24 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf.d41d8cd98f00b204e9800998ecf8427e.inverted
...
bio_graphics_ff_cache_80$ ls -lt
total 428
-rw-r--r--  1 www  www  20935 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf.5e0728b254c39078d9572feaa94b2a28.inverted
-rw-r--r--  1 www  www     24 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf.d41d8cd98f00b204e9800998ecf8427e.inverted
-rw-r--r--  1 www  www  20935 May 14 11:48 _opt_gbrowse_conf_gmax1.01.conf.87e6768252af88484bd145fe17ec6bf2.inverted
...
```

In the bio_graphics_ff_cache_UID directory of the data source for the gbrowse instance that experienced the internal server error issue, the cache file, which was left behind, seemed to be causing the a new .inverted file from being created (maybe the cache file was corrupt, as I could reproduce the mod_fcgid segfault & resulting internal server error by reintroducing the cache file in the bio_graphics_ff_cache_UID directory of a working GBrowse instance)

```
$ ls -lt *gmax1.01*|head -n 3
-rw-r--r--  1 www  wheel  155648 May 11 11:23 _opt_gbrowse_conf_gmax1.01.conf
-rw-r--r--  1 www  wheel   20935 May 11 11:15 _opt_gbrowse_conf_gmax1.01.conf.0209eb0705cabf3b96824266bb54db57.inverted
-rw-r--r--  1 www  wheel      24 May 11 11:15 _opt_gbrowse_conf_gmax1.01.conf.d41d8cd98f00b204e9800998ecf8427e.inverted
```

This fix should hopefully prevent the cache file from being created unnecessarily, and (indirectly) address the issue we observed.
