### PR TITLE
Fix summary mode for features with no source_tag

### DIFF
--- a/lib/Bio/Graphics/Browser2/RenderPanels.pm
+++ b/lib/Bio/Graphics/Browser2/RenderPanels.pm
@@ -2409,7 +2409,7 @@ sub feature2label {
     my $feature = shift;
     my $type2label = $self->{_type2label} or die "no type2label map defined";
     my $type = eval {$feature->type} || eval{$feature->source_tag} || eval{$feature->primary_tag} or return;
-    (my $basetype = $type) =~ s/:.+$//;
+    (my $basetype = $type) =~ s/:.*$//;
     my $labels = $type2label->{$type}||$type2label->{$basetype} or return;
     my @labels = keys %$labels;
     return @labels;


### PR DESCRIPTION
Summary mode doesn't work for features that lack a source_tag. In the original code below, the $type variable is assumed to contain a string of the form "primary_tag:source_tag", where the source_tag is not a null string; however, in a Bio::DB::SeqFeature::Store::DBI::SQLite database that was loaded loaded from a GFF3 that had "." in the source column, the following types exist:

```
$ sqlite3 track.db 'select * from typelist;'
1|gene:
2|mRNA:
3|five_prime_UTR:
4|exon:
5|CDS:
6|three_prime_UTR:
```

This was causing the track to render empty when the user zoomed out to a level that activated summary mode.

The regular expression that sets $basetype was updated to work then the $type variable is of the form "primary_tag:".
