### PR TITLE
Don't spawn child processes if there are no uncached requests

### DIFF
--- a/lib/Bio/Graphics/Browser2/RenderPanels.pm
+++ b/lib/Bio/Graphics/Browser2/RenderPanels.pm
@@ -147,12 +147,16 @@ sub request_panels {
   my $do_local  = @$local_labels;
   my $do_remote = @$remote_labels;
 
+  if (!($do_local || $do_remote)) {
+      warn "[$$] No uncached requests to process..." if DEBUG;
+      return $data_destinations;
+  }
   # In the case of a deferred request we fork.
   # Parent returns the list of requests.
   # Child processes the requests in the background.
   # If both local and remote requests are needed, then we
   # fork a second time and process them in parallel.
-  if ($args->{deferred}) {
+  elsif ($args->{deferred}) {
 
       # precache local databases into cache
       my $length = $self->segment_length;


### PR DESCRIPTION
If there are no uncached tracks, don't spawn child processes to handle empty requests. The parent process code isn't expecting to wait for the children in this case, which, using Perl 5.18.4 running under mod_fcgid 2.3.9 on Apache 2.2.29, would apparently result in the FastCGI process terminating after issuing the error: 

```
SIGCHLD received, but no signal handler set.
[Tue May 12 15:43:25 2015] [warn] [client 192.168.0.1] mod_fcgid: error reading data, FastCGI server closed connection, referer: http://soybase.org/gb2/gbrowse/gmax1.01/
```
