### PR TITLE
Support PDF generation with svg2pdf

### DIFF
--- a/cgi-bin/gbrowse_img
+++ b/cgi-bin/gbrowse_img
@@ -227,8 +227,7 @@ sub render_image {
 
 
     my $convert_to_pdf;
-    if ($format eq 'PDF' && `which inkscape`) {
-	$convert_to_pdf++;
+    if ($format eq 'PDF' && ($convert_to_pdf = `which svg2pdf` || `which inkscape`)) {
 	$format = 'GD::SVG';
     }
 
@@ -274,8 +273,11 @@ sub render_image {
 
 	print $infh $img_data or die "$in: $!";
 	close $infh;
-
-	system "inkscape -z --without-gui --export-pdf=$out $in 3<&1 1>&2 2>&3 | grep -v GDK_IS_DISPLAY";
+    if ($convert_to_pdf =~ /svg2pdf$/) {
+       system "svg2pdf $in $out 3<&1 1>&2 2>&3";
+    } else {
+	    system "inkscape -z --without-gui --export-pdf=$out $in 3<&1 1>&2 2>&3 | grep -v GDK_IS_DISPLAY";
+    }
 	open (my $fh,'<',$out) or die "$out: $!";
 	while (<$fh>) {print $_}
 	close $fh;

--- a/lib/Bio/Graphics/Browser2/Render/HTML.pm
+++ b/lib/Bio/Graphics/Browser2/Render/HTML.pm
@@ -2551,6 +2551,7 @@ sub can_generate_pdf {
     return $CAN_PDF = $source->global_setting('generate pdf') 
 	if defined $source->global_setting('generate pdf');
 
+    return $CAN_PDF=1 if `which svg2pdf`;
     return $CAN_PDF=0 unless `which inkscape`;
     # see whether we have the needed .inkscape and .gnome2 directories
     my $home = (getpwuid($<))[7];


### PR DESCRIPTION
svg2pdf is much lighter-weight than inkscape, having far fewer dependencies, but utilizing the same underlying library (cairo) as inkscape to generate PDF from SVG.
