### PR TITLE
escape track list separators in URIs

### DIFF
--- a/lib/Bio/Graphics/Browser2/Render.pm
+++ b/lib/Bio/Graphics/Browser2/Render.pm
@@ -3881,7 +3881,7 @@ sub join_selected_tracks {
 sub join_tracks {
     my $self = shift;
     my $tracks = shift;
-    return CGI::escape(join (LABEL_SEPARATOR,@$tracks));
+    return join (LABEL_SEPARATOR,@$tracks));
 }
 
 sub bookmark_link {
@@ -3974,7 +3974,7 @@ sub image_link {
     my $stop     = param('view_stop')  || $settings->{view_stop};
     $stop++;
     my $name     = "$settings->{ref}:$start..$stop";
-    my $selected = $self->join_selected_tracks;
+    my $selected = CGI::escape($self->join_selected_tracks);
     my $options  = join '+',map { join '+', CGI::escape($_),$settings->{features}{$_}{options}
                              } map {/\s/?"$_":$_}
     grep {

--- a/lib/Bio/Graphics/Browser2/Render.pm
+++ b/lib/Bio/Graphics/Browser2/Render.pm
@@ -3881,7 +3881,7 @@ sub join_selected_tracks {
 sub join_tracks {
     my $self = shift;
     my $tracks = shift;
-    return join LABEL_SEPARATOR,@$tracks;
+    return CGI::escape(join (LABEL_SEPARATOR,@$tracks));
 }
 
 sub bookmark_link {

--- a/lib/Bio/Graphics/Browser2/Render.pm
+++ b/lib/Bio/Graphics/Browser2/Render.pm
@@ -3881,7 +3881,7 @@ sub join_selected_tracks {
 sub join_tracks {
     my $self = shift;
     my $tracks = shift;
-    return join (LABEL_SEPARATOR,@$tracks));
+    return join LABEL_SEPARATOR,@$tracks;
 }
 
 sub bookmark_link {


### PR DESCRIPTION
GBrowse fails to export SVG and PNG images when used with versions of Apache HTTPD that are patched for [CVE-2016-87430](http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2016-8743) due to whitespace track separators not being escaped in generated URIs. The resulting Apache error log includes,

```
AH02430: Response header 'Location' value of 'http://.../cgi-bin/gbrowse_img/...;format=GD::SVG;keystyle=between;grid=1;...' contains invalid characters, aborting request
```

Probably relevant to
https://sourceforge.net/p/gmod/mailman/message/36018459/
https://sourceforge.net/p/gmod/mailman/message/35841165/

